### PR TITLE
add kwargs for compatibilities

### DIFF
--- a/src/indobenchmark/tokenization_indonlg.py
+++ b/src/indobenchmark/tokenization_indonlg.py
@@ -359,8 +359,8 @@ class IndoNLGTokenizer(PreTrainedTokenizer):
         self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
         self.sp_model.Load(self.vocab_file)
 
-    def decode(self, inputs, skip_special_tokens=False):     
-        outputs = super().decode(inputs, skip_special_tokens=skip_special_tokens)
+    def decode(self, inputs, skip_special_tokens=False, **kwargs):     
+        outputs = super().decode(inputs, skip_special_tokens=skip_special_tokens, **kwargs)
         return outputs.replace(' ','').replace('▁', ' ')
     
     def _pad_decoder(


### PR DESCRIPTION
Prevent this kind of error:

```
Traceback (most recent call last):
  File "main.py", line 66, in <module>
    main(args)
  File "/home/nafkhanzam/kode/nafkhanzam/thesis/AMRBART/indobart-pre-train/run_multitask_unified_pretraining.py", line 1301, in main
    global_step, tr_loss = train(
  File "/home/nafkhanzam/kode/nafkhanzam/thesis/AMRBART/indobart-pre-train/run_multitask_unified_pretraining.py", line 324, in train
    save_dummy_batch(
  File "/home/nafkhanzam/kode/nafkhanzam/thesis/AMRBART/indobart-pre-train/common/utils.py", line 78, in save_dummy_batch
    ith_tok_dict["input_tokens"] = ids_to_clean_text(tokenizer, input_ids[idx])
  File "/home/nafkhanzam/kode/nafkhanzam/thesis/AMRBART/indobart-pre-train/common/utils.py", line 65, in ids_to_clean_text
    gen_text = tokenizer.batch_decode(generated_ids)
  File "/home/nafkhanzam/.conda/envs/thesis/lib/python3.8/site-packages/transformers/tokenization_utils_base.py", line 3328, in batch_decode
    return [
  File "/home/nafkhanzam/.conda/envs/thesis/lib/python3.8/site-packages/transformers/tokenization_utils_base.py", line 3329, in <listcomp>
    self.decode(
TypeError: decode() got an unexpected keyword argument 'clean_up_tokenization_spaces'
```