### PR TITLE
Remove the __len__ method from the tokenizer

### DIFF
--- a/src/indobenchmark/tokenization_indonlg.py
+++ b/src/indobenchmark/tokenization_indonlg.py
@@ -232,9 +232,6 @@ class IndoNLGTokenizer(PreTrainedTokenizer):
                 input_batch['labels'] = labels
                 
                 return input_batch
-
-    def __len__(self):
-        return max(self.special_ids_to_tokens) + 1
     
     def get_special_tokens_mask(
         self, token_ids_0: List[int], token_ids_1: Optional[List[int]] = None, already_has_special_tokens: bool = False


### PR DESCRIPTION
The previous implementation of the __len__ tokenizer of IndoNLGTokenizer override the __len__ by the PretrainedTokenizerBase which creates inconsistency of the tokenizer length before and after adding special tokens